### PR TITLE
Update addon.lua

### DIFF
--- a/Kui_Nameplates/addon.lua
+++ b/Kui_Nameplates/addon.lua
@@ -216,10 +216,10 @@ local function OnEvent(self,event,...)
             ClassNameplateBarWindwalkerMonkFrame:UnregisterAllEvents()
             --luacheck:globals ClassNameplateBarPaladinFrame
             ClassNameplateBarPaladinFrame:UnregisterAllEvents()
-            --luacheck:globals ClassNameplateBarRogueDruidFrame
-            if (ClassNameplateBarRogueDruidFrame ~= nil) then
-				ClassNameplateBarRogueDruidFrame:UnregisterAllEvents()
-			end
+            --luacheck:globals ClassNameplateBarRogueFrame
+            ClassNameplateBarRogueFrame:UnregisterAllEvents()
+            --luacheck:globals ClassNameplateBarDruidFrame
+            ClassNameplateBarDruidFrame:UnregisterAllEvents()
             --luacheck:globals ClassNameplateBarWarlockFrame
             ClassNameplateBarWarlockFrame:UnregisterAllEvents()
             --luacheck:globals ClassNameplateBrewmasterBarFrame


### PR DESCRIPTION
Not sure if I'm doing this correctly so apologies if I'm wrong, but I think the ClassNameplateBarRogueDruidFrame was just split into a frame for druid and a frame for rogue. The proposed change loads without error and I think should do what the original code did.